### PR TITLE
Fix date type decoder

### DIFF
--- a/src/AWS/CognitoIdentity.elm
+++ b/src/AWS/CognitoIdentity.elm
@@ -1651,7 +1651,7 @@ type alias DeleteIdentitiesInput =
 {-| The DateType data model.
 -}
 type alias DateType =
-    String
+    Int
 
 
 {-| The Credentials data model.
@@ -1956,7 +1956,7 @@ credentialsDecoder =
 -}
 dateTypeDecoder : Decoder DateType
 dateTypeDecoder =
-    Json.Decode.string
+    Json.Decode.int
 
 
 {-| Codec for DeveloperProviderName.


### PR DESCRIPTION
Based on the [cognito service file](https://github.com/aws/aws-sdk-js/blob/88d145e931f272da4284537cbf6baf6a315023ab/apis/cognito-identity-2014-06-30.normal.json#L926) the DateType is a timestamp which is internally represented as int (Unix secons) for AWSCognito, specifcally the expiration field of identity credentials


As per the the sdk code [here](https://github.com/aws/aws-sdk-js/blob/307e82673b48577fce4389e4ce03f95064e8fe0d/lib/param_validator.js#L140), the timestamp can be iso string , date object or a unix timestamp

 